### PR TITLE
Improve how photos are shown in on people#show

### DIFF
--- a/app/assets/stylesheets/resources/people.css.scss
+++ b/app/assets/stylesheets/resources/people.css.scss
@@ -1,9 +1,0 @@
-body.people.index {
-  ul.people.media-list li {
-     width: 380px;
-     height: 150px;
-     margin-top: 20px;
-     margin-right: 40px;
-     float: left;
-  }
-}

--- a/app/assets/stylesheets/resources/people.css.scss.erb
+++ b/app/assets/stylesheets/resources/people.css.scss.erb
@@ -1,0 +1,19 @@
+body.people.index {
+  ul.people.media-list li {
+     width: 380px;
+     height: 150px;
+     margin-top: 20px;
+     margin-right: 40px;
+     float: left;
+  }
+}
+
+body.people.show {
+  table.photos {
+    td.photo img.zoomable {
+      max-height: <%= Settings.views.photos.max_height %>px;
+      cursor: -webkit-zoom-in;
+      cursor: -moz-zoom-in;
+    }
+  }
+}

--- a/app/views/people/show.html.slim
+++ b/app/views/people/show.html.slim
@@ -1,3 +1,11 @@
+- @person.photos.each do |photo|
+  - if photo.height > Settings.views.photos.max_height
+    .modal.fade id=dom_id(photo) role="dialog"
+      .modal-dialog
+        .modal-content
+          .modal-body
+            img src=photo.url
+
 .row
   .col-md-3
     p.text-center
@@ -114,21 +122,23 @@
         hr
 
         h3 Photos
-        table.table
+        table.table.photos
           tr
             th Photo
             th Type
-            th
-              abbr title="Uniform Resource Locator" URL
+            th File
             th Height
             th Width
           - @person.photos.each do |photo|
             tr
-              td
-                / TODO: max-height and full size popup
-                img.img-rounded src=photo.url alt=photo.type
+              td.photo
+                - if photo.height > Settings.views.photos.max_height
+                  a data-toggle="modal" data-target="##{dom_id(photo)}"
+                    img.img-rounded.zoomable src=photo.url alt=photo.type
+                - else
+                  img.img-rounded src=photo.url alt=photo.type
               td = photo.type
-              td = link_to photo.url, photo.url
+              td.url = link_to File.basename(photo.url), photo.url
               td = photo.height
               td = photo.width
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,3 +22,7 @@ email:
 exceptions:
   mail_to:
   - appdev@biola.edu
+
+views:
+  photos:
+    max_height: 150


### PR DESCRIPTION
Show the photo at 150px max height and full size on click and show
file name instead of full URL to prevent overflow.