### PR TITLE
Add more intelligence to the changeset status.

### DIFF
--- a/app/presenters/changeset_presenter.rb
+++ b/app/presenters/changeset_presenter.rb
@@ -48,7 +48,8 @@ class ChangesetPresenter < ApplicationPresenter
     elsif sync_log.errored_at?
       Status.new(:error, 1, "error: #{sync_log.message}")
     elsif sync_log.succeeded_at?
-      Status.new(:success, 4, sync_log.action.to_s)
+      options = {'create' => 4, 'update' => 5, 'skip' => 6}
+      Status.new(:success, options[sync_log.action.to_s], sync_log.action.to_s)
     else
       Status.new(:started, 3, "sync started #{time_ago_in_words(sync_log.started_at)} ago")
     end


### PR DESCRIPTION
Before when a change_sync was successful three keepers just blindly took
the top change_sync and made it the status of the changeset. This lead
to misleading information like a change sync updating one service and
skipping another, and the changeset took skip instead of update.