### PR TITLE
Add changeset presenter for destroy

### DIFF
--- a/app/presenters/changeset_presenter.rb
+++ b/app/presenters/changeset_presenter.rb
@@ -47,8 +47,10 @@ class ChangesetPresenter < ApplicationPresenter
       Status.new(:unsynced, 2, 'unsynced')
     elsif sync_log.errored_at?
       Status.new(:error, 1, "error: #{sync_log.message}")
+    elsif sync_log.action ==:destroy
+      Status.new(:deleted, 4, 'deleted')
     elsif sync_log.succeeded_at?
-      options = {'create' => 4, 'update' => 5, 'skip' => 6}
+      options = {'create' => 5, 'update' => 6, 'skip' => 7}
       Status.new(:success, options[sync_log.action.to_s], sync_log.action.to_s)
     else
       Status.new(:started, 3, "sync started #{time_ago_in_words(sync_log.started_at)} ago")

--- a/app/presenters/changeset_presenter.rb
+++ b/app/presenters/changeset_presenter.rb
@@ -47,10 +47,8 @@ class ChangesetPresenter < ApplicationPresenter
       Status.new(:unsynced, 2, 'unsynced')
     elsif sync_log.errored_at?
       Status.new(:error, 1, "error: #{sync_log.message}")
-    elsif sync_log.action ==:destroy
-      Status.new(:deleted, 4, 'deleted')
     elsif sync_log.succeeded_at?
-      options = {'create' => 5, 'update' => 6, 'skip' => 7}
+      options = {'destroy', => 4'create' => 5, 'update' => 6, 'skip' => 7}
       Status.new(:success, options[sync_log.action.to_s], sync_log.action.to_s)
     else
       Status.new(:started, 3, "sync started #{time_ago_in_words(sync_log.started_at)} ago")

--- a/app/presenters/changeset_presenter.rb
+++ b/app/presenters/changeset_presenter.rb
@@ -48,7 +48,7 @@ class ChangesetPresenter < ApplicationPresenter
     elsif sync_log.errored_at?
       Status.new(:error, 1, "error: #{sync_log.message}")
     elsif sync_log.succeeded_at?
-      options = {'destroy', => 4'create' => 5, 'update' => 6, 'skip' => 7}
+      options = {'destroy' => 4, 'create' => 5, 'update' => 6, 'skip' => 7}
       Status.new(:success, options[sync_log.action.to_s], sync_log.action.to_s)
     else
       Status.new(:started, 3, "sync started #{time_ago_in_words(sync_log.started_at)} ago")


### PR DESCRIPTION
Changeset presenter didn't know how to deal with a "destroy" message coming through a sync_log so it errored out whenever it found one. This gives it top priority  as far as a successful message (destroy is still success)